### PR TITLE
Issue removing weak event handlers created using delegate inference

### DIFF
--- a/Framework/PostSharp.Samples.WeakEvent/WeakEventAttribute.cs
+++ b/Framework/PostSharp.Samples.WeakEvent/WeakEventAttribute.cs
@@ -124,7 +124,7 @@ namespace PostSharp.Samples.WeakEvent
 
         handlers =
           handlers.RemoveAll(
-            o => ReferenceEquals(((WeakReference) o).Target, handler));
+            o => ((WeakReference)o).Target?.Equals(handler) ?? false);
 
         return handlers.IsEmpty;
       }


### PR DESCRIPTION
After changing our code from using an older extension method based pattern for Weak Events with a bunch of supporting class to use this sample one of our unit tests started failing. I can't include all the code and don't have much time available or I'd make a repro project, but here's a snippet from the unit test:

```csharp
addresses.ListChanged += PropertyChangeTests_ListChanged1;

// make a change to the list...clientAddresses_ListChanged1 should run
ChildDocument address1 = addresses.AddNew();

// verify that PropertyChangeTests_ListChanged1 fired
Assert.IsTrue(listChanged1Called, "Expecting ListChanged event handler to run but it did not.");
this.Reset();

// unregister/register for the list changed event, using a different handler
addresses.ListChanged -= PropertyChangeTests_ListChanged2; // this line should also do nothing

ChildDocument address2 = addresses.AddNew(); // force the list to change again
// verify that PropertyChangeTests_ListChanged1 fired
Assert.IsTrue(listChanged1Called, "Expecting ListChanged event handler to run but it did not.");
this.Reset();

addresses.ListChanged += PropertyChangeTests_ListChanged2; // register for *another* ListChanged event handler, on this same instance

addresses.Remove(address1); // force the list to change yet again

// verify that PropertyChangeTests_PropertyChanging1 fired
Assert.IsTrue(listChanged1Called, "Expecting ListChanged event handler to run but it did not.");
// verify that PropertyChangeTests_PropertyChanging2 fired
Assert.IsTrue(listChanged2Called, "Expecting ListChanged event handler to run but it did not.");
this.Reset();

// unregister both event handlers
addresses.ListChanged -= PropertyChangeTests_ListChanged1;
addresses.ListChanged -= PropertyChangeTests_ListChanged2;

// change the property value again
addresses.Remove(address2);

// verify that the event handlers did *not* fire this time
Assert.IsFalse(listChanged1Called, "Expecting ListChanged event handler not to run but it did.");
Assert.IsFalse(listChanged2Called, "Expecting ListChanged event handler not to run but it did.");
```

The last two assert statements were failing and it turns out the primary difference looks like it's because using the delegate inference C# language feature, the delegate removal was being handed a new instance. For example

```csharp
obj.Event += HandlerMethod;
// blah
obj.Event -= HandlerMethod;
```

appears to translate to:

```csharp
obj.Event += new EventHandler(HandlerMethod)
// blah
obj.Event -= new EventHandler(HandlerMethod)
```

which failed the `ReferenceEquals` test, whereas the following pattern more common before C# 2 would have worked fine

```csharp
var handler = new EventHandler(HandlerMethod);
obj.Event += handler;
// blah
obj.Event -= handler;
```

In looking into how normal multicast delegates don't suffer this problem, I found a helpful [Stack Overflow](https://stackoverflow.com/a/1626826/8543) answer quoting the C# specification (§7.9.8) and changed the test to use `.Equals` instead